### PR TITLE
add macOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/*
+.idea

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This GitHub action connects your runner to your private network.
 2. Amazon Linux 2
 3. Windows Server 2019 and 2022
 4. macos-latest
-5. Self-hosted macos runners, requires `brew` to be installed, and running on a user that has passwordless sudo enabled. 
+5. Self-hosted macOS runners, only if EdgeGuardian app is not installed. Requires `brew` to be installed, and running on a user that has passwordless sudo enabled. 
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This GitHub action connects your runner to your private network.
 1. ubuntu-latest
 2. Amazon Linux 2
 3. Windows Server 2019 and 2022
+4. macos-latest
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This GitHub action connects your runner to your private network.
 2. Amazon Linux 2
 3. Windows Server 2019 and 2022
 4. macos-latest
+5. Self-hosted macos runners, requires `brew` to be installed, and running on a user that has passwordless sudo enabled. 
 
 ## Inputs
 

--- a/cleanup.js
+++ b/cleanup.js
@@ -19,8 +19,8 @@ try {
         shell('egctl logout');
     } else if (os.platform() == 'win32') {
         cmd(`curl localhost:3128/config & curl localhost:3128/connections`);
-    } else if (os.platform() == "darwin") {
-        shell(`curl localhost:3128/config & curl localhost:3128/connections`);
+    } else if (os.platform() === "darwin") {
+        shell('curl localhost:3128/connections');
     } else {
         let platform = os.platform();
         core.setFailed(`${platform} not supported`);

--- a/cleanup.js
+++ b/cleanup.js
@@ -28,6 +28,7 @@ try {
                 sudo egctl logout
                 sudo brew services stop eg-client
                 sudo rm -rf $(brew --prefix)/Cellar/eg-client/0.0.1
+                brew cleanup
             fi
         `)
     } else {

--- a/cleanup.js
+++ b/cleanup.js
@@ -19,8 +19,9 @@ try {
         shell('egctl logout');
     } else if (os.platform() == 'win32') {
         cmd(`curl localhost:3128/config & curl localhost:3128/connections`);
-    } else if (os.platform() === "darwin") {
+    } else if (os.platform() == "darwin") {
         shell('curl localhost:3128/connections');
+        shell('sudo egctl logout');
     } else {
         let platform = os.platform();
         core.setFailed(`${platform} not supported`);

--- a/cleanup.js
+++ b/cleanup.js
@@ -1,5 +1,5 @@
 const core = require('@actions/core');
-const { shell, cmd } = require('./shell.js');
+const { shell, cmd, is_ui_client_running_macos } = require('./shell.js');
 import * as os from 'os';
 
 if (core.getState("EG_FAILED") == "true") {
@@ -20,8 +20,13 @@ try {
     } else if (os.platform() == 'win32') {
         cmd(`curl localhost:3128/config & curl localhost:3128/connections`);
     } else if (os.platform() == "darwin") {
-        shell('curl localhost:3128/connections');
-        shell('sudo egctl logout');
+        let result = await is_ui_client_running_macos();
+        if (result === undefined || result === 0) {
+            shell('curl localhost:3128/connections');
+            shell('sudo egctl logout');
+            shell('sudo brew services stop eg-client');
+            shell('sudo rm -rf $(brew --prefix)/Cellar/eg-client/0.0.1')
+        }
     } else {
         let platform = os.platform();
         core.setFailed(`${platform} not supported`);

--- a/cleanup.js
+++ b/cleanup.js
@@ -19,6 +19,8 @@ try {
         shell('egctl logout');
     } else if (os.platform() == 'win32') {
         cmd(`curl localhost:3128/config & curl localhost:3128/connections`);
+    } else if (os.platform() == "macos") {
+        shell(`curl localhost:3128/config & curl localhost:3128/connections`);
     } else {
         let platform = os.platform();
         core.setFailed(`${platform} not supported`);

--- a/cleanup.js
+++ b/cleanup.js
@@ -1,5 +1,5 @@
 const core = require('@actions/core');
-const { shell, cmd, is_ui_client_running_macos } = require('./shell.js');
+const { shell, cmd, is_ui_client_installed_macos } = require('./shell.js');
 import * as os from 'os';
 
 if (core.getState("EG_FAILED") == "true") {
@@ -20,12 +20,14 @@ try {
     } else if (os.platform() == 'win32') {
         cmd(`curl localhost:3128/config & curl localhost:3128/connections`);
     } else if (os.platform() == "darwin") {
-        let result = await is_ui_client_running_macos();
-        if (result === undefined || result === 0) {
+        let result = await is_ui_client_installed_macos();
+        if (result === undefined || result === 1) {
             shell('curl localhost:3128/connections');
             shell('sudo egctl logout');
             shell('sudo brew services stop eg-client');
             shell('sudo rm -rf $(brew --prefix)/Cellar/eg-client/0.0.1')
+        } else {
+            console.log("UI client already installed, skipping install");
         }
     } else {
         let platform = os.platform();

--- a/cleanup.js
+++ b/cleanup.js
@@ -1,5 +1,5 @@
 const core = require('@actions/core');
-const { shell, cmd, is_ui_client_installed_macos } = require('./shell.js');
+const { shell, cmd } = require('./shell.js');
 import * as os from 'os';
 
 if (core.getState("EG_FAILED") == "true") {
@@ -20,15 +20,16 @@ try {
     } else if (os.platform() == 'win32') {
         cmd(`curl localhost:3128/config & curl localhost:3128/connections`);
     } else if (os.platform() == "darwin") {
-        let result = await is_ui_client_installed_macos();
-        if (result === undefined || result === 1) {
-            shell('curl localhost:3128/connections');
-            shell('sudo egctl logout');
-            shell('sudo brew services stop eg-client');
-            shell('sudo rm -rf $(brew --prefix)/Cellar/eg-client/0.0.1')
-        } else {
-            console.log("UI client already installed, skipping install");
-        }
+        shell(`
+            if [ -d /Applications/EdgeGuardian.app ]; then
+                echo "UI client already installed, skipping cleanup";
+            else
+                curl localhost:3128/connections
+                sudo egctl logout
+                sudo brew services stop eg-client
+                sudo rm -rf $(brew --prefix)/Cellar/eg-client/0.0.1
+            fi
+        `)
     } else {
         let platform = os.platform();
         core.setFailed(`${platform} not supported`);

--- a/cleanup.js
+++ b/cleanup.js
@@ -19,7 +19,7 @@ try {
         shell('egctl logout');
     } else if (os.platform() == 'win32') {
         cmd(`curl localhost:3128/config & curl localhost:3128/connections`);
-    } else if (os.platform() == "macos") {
+    } else if (os.platform() == "darwin") {
         shell(`curl localhost:3128/config & curl localhost:3128/connections`);
     } else {
         let platform = os.platform();

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -4248,6 +4248,7 @@ try {
                 sudo egctl logout
                 sudo brew services stop eg-client
                 sudo rm -rf $(brew --prefix)/Cellar/eg-client/0.0.1
+                brew cleanup
             fi
         `)
     } else {

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -4238,6 +4238,8 @@ try {
         shell('egctl logout');
     } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'win32') {
         cmd(`curl localhost:3128/config & curl localhost:3128/connections`);
+    } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == "macos") {
+        shell(`curl localhost:3128/config & curl localhost:3128/connections`);
     } else {
         let platform = os__WEBPACK_IMPORTED_MODULE_0__.platform();
         core.setFailed(`${platform} not supported`);

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -1,6 +1,56 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
+/***/ 722:
+/***/ ((module, __webpack_exports__, __nccwpck_require__) => {
+
+"use strict";
+__nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__) => {
+__nccwpck_require__.r(__webpack_exports__);
+/* harmony import */ var os__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(87);
+/* harmony import */ var os__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(os__WEBPACK_IMPORTED_MODULE_0__);
+const core = __nccwpck_require__(186);
+const { shell, cmd, is_ui_client_running_macos } = __nccwpck_require__(752);
+
+
+if (core.getState("EG_FAILED") == "true") {
+    if (core.getInput('submit_diagnostics_on_failure') == "true") {
+        try {
+            shell('egctl advanced log-upload');
+        } catch (error) { }
+    }
+    try {
+        shell('cat /var/log/edgeguardian/datapath.log || true;')
+    } catch (error) { }
+}
+
+try {
+    if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'linux') {
+        shell('curl localhost:3128/connections');
+        shell('egctl logout');
+    } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'win32') {
+        cmd(`curl localhost:3128/config & curl localhost:3128/connections`);
+    } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == "darwin") {
+        let result = await is_ui_client_running_macos();
+        if (result === undefined || result === 0) {
+            shell('curl localhost:3128/connections');
+            shell('sudo egctl logout');
+            shell('sudo brew services stop eg-client');
+            shell('sudo rm -rf $(brew --prefix)/Cellar/eg-client/0.0.1')
+        }
+    } else {
+        let platform = os__WEBPACK_IMPORTED_MODULE_0__.platform();
+        core.setFailed(`${platform} not supported`);
+    }
+} catch (error) {
+    core.setFailed(error.message);
+}
+
+__webpack_handle_async_dependencies__();
+}, 1);
+
+/***/ }),
+
 /***/ 351:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -3981,7 +4031,7 @@ async function shell(command) {
             "-c",
             command,
         ];
-        await exec.exec("/bin/sh", args);
+        return await exec.exec("/bin/sh", args);
     } catch (error) {
         core.setFailed(error.message);
     }
@@ -4013,9 +4063,22 @@ async function cmd(command) {
     }
 }
 
+async function is_ui_client_running_macos() {
+    return await shell(`
+        if ! pgrep EdgeGuardian &> /dev/null 2>&1; then
+            echo "EdgeGuardian not running"
+            exit 0
+        else
+            echo "EdgeGuardian is running"
+            exit 1
+        fi
+    `)
+}
+
 exports.shell = shell;
 exports.powershell = powershell;
 exports.cmd = cmd;
+exports.is_ui_client_running_macos = is_ui_client_running_macos;
 
 
 /***/ }),
@@ -4165,6 +4228,80 @@ module.exports = require("util");
 /******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/async module */
+/******/ 	(() => {
+/******/ 		var webpackThen = typeof Symbol === "function" ? Symbol("webpack then") : "__webpack_then__";
+/******/ 		var webpackExports = typeof Symbol === "function" ? Symbol("webpack exports") : "__webpack_exports__";
+/******/ 		var completeQueue = (queue) => {
+/******/ 			if(queue) {
+/******/ 				queue.forEach((fn) => (fn.r--));
+/******/ 				queue.forEach((fn) => (fn.r-- ? fn.r++ : fn()));
+/******/ 			}
+/******/ 		}
+/******/ 		var completeFunction = (fn) => (!--fn.r && fn());
+/******/ 		var queueFunction = (queue, fn) => (queue ? queue.push(fn) : completeFunction(fn));
+/******/ 		var wrapDeps = (deps) => (deps.map((dep) => {
+/******/ 			if(dep !== null && typeof dep === "object") {
+/******/ 				if(dep[webpackThen]) return dep;
+/******/ 				if(dep.then) {
+/******/ 					var queue = [];
+/******/ 					dep.then((r) => {
+/******/ 						obj[webpackExports] = r;
+/******/ 						completeQueue(queue);
+/******/ 						queue = 0;
+/******/ 					});
+/******/ 					var obj = {};
+/******/ 												obj[webpackThen] = (fn, reject) => (queueFunction(queue, fn), dep.catch(reject));
+/******/ 					return obj;
+/******/ 				}
+/******/ 			}
+/******/ 			var ret = {};
+/******/ 								ret[webpackThen] = (fn) => (completeFunction(fn));
+/******/ 								ret[webpackExports] = dep;
+/******/ 								return ret;
+/******/ 		}));
+/******/ 		__nccwpck_require__.a = (module, body, hasAwait) => {
+/******/ 			var queue = hasAwait && [];
+/******/ 			var exports = module.exports;
+/******/ 			var currentDeps;
+/******/ 			var outerResolve;
+/******/ 			var reject;
+/******/ 			var isEvaluating = true;
+/******/ 			var nested = false;
+/******/ 			var whenAll = (deps, onResolve, onReject) => {
+/******/ 				if (nested) return;
+/******/ 				nested = true;
+/******/ 				onResolve.r += deps.length;
+/******/ 				deps.map((dep, i) => (dep[webpackThen](onResolve, onReject)));
+/******/ 				nested = false;
+/******/ 			};
+/******/ 			var promise = new Promise((resolve, rej) => {
+/******/ 				reject = rej;
+/******/ 				outerResolve = () => (resolve(exports), completeQueue(queue), queue = 0);
+/******/ 			});
+/******/ 			promise[webpackExports] = exports;
+/******/ 			promise[webpackThen] = (fn, rejectFn) => {
+/******/ 				if (isEvaluating) { return completeFunction(fn); }
+/******/ 				if (currentDeps) whenAll(currentDeps, fn, rejectFn);
+/******/ 				queueFunction(queue, fn);
+/******/ 				promise.catch(rejectFn);
+/******/ 			};
+/******/ 			module.exports = promise;
+/******/ 			body((deps) => {
+/******/ 				if(!deps) return outerResolve();
+/******/ 				currentDeps = wrapDeps(deps);
+/******/ 				var fn, result;
+/******/ 				var promise = new Promise((resolve, reject) => {
+/******/ 					fn = () => (resolve(result = currentDeps.map((d) => (d[webpackExports]))));
+/******/ 					fn.r = 0;
+/******/ 					whenAll(currentDeps, fn, reject);
+/******/ 				});
+/******/ 				return fn.r ? promise : result;
+/******/ 			}).then(outerResolve, reject);
+/******/ 			isEvaluating = false;
+/******/ 		};
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
 /******/ 		// getDefaultExport function for compatibility with non-harmony modules
@@ -4210,47 +4347,12 @@ module.exports = require("util");
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
-var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be in strict mode.
-(() => {
-"use strict";
-__nccwpck_require__.r(__webpack_exports__);
-/* harmony import */ var os__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(87);
-/* harmony import */ var os__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(os__WEBPACK_IMPORTED_MODULE_0__);
-const core = __nccwpck_require__(186);
-const { shell, cmd } = __nccwpck_require__(752);
-
-
-if (core.getState("EG_FAILED") == "true") {
-    if (core.getInput('submit_diagnostics_on_failure') == "true") {
-        try {
-            shell('egctl advanced log-upload');
-        } catch (error) { }
-    }
-    try {
-        shell('cat /var/log/edgeguardian/datapath.log || true;')
-    } catch (error) { }
-}
-
-try {
-    if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'linux') {
-        shell('curl localhost:3128/connections');
-        shell('egctl logout');
-    } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'win32') {
-        cmd(`curl localhost:3128/config & curl localhost:3128/connections`);
-    } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == "darwin") {
-        shell('curl localhost:3128/connections');
-        shell('sudo egctl logout');
-    } else {
-        let platform = os__WEBPACK_IMPORTED_MODULE_0__.platform();
-        core.setFailed(`${platform} not supported`);
-    }
-} catch (error) {
-    core.setFailed(error.message);
-}
-
-})();
-
-module.exports = __webpack_exports__;
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module used 'module' so it can't be inlined
+/******/ 	var __webpack_exports__ = __nccwpck_require__(722);
+/******/ 	module.exports = __webpack_exports__;
+/******/ 	
 /******/ })()
 ;

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -10,7 +10,7 @@ __nccwpck_require__.r(__webpack_exports__);
 /* harmony import */ var os__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(87);
 /* harmony import */ var os__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(os__WEBPACK_IMPORTED_MODULE_0__);
 const core = __nccwpck_require__(186);
-const { shell, cmd, is_ui_client_running_macos } = __nccwpck_require__(752);
+const { shell, cmd, is_ui_client_installed_macos } = __nccwpck_require__(752);
 
 
 if (core.getState("EG_FAILED") == "true") {
@@ -31,12 +31,14 @@ try {
     } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'win32') {
         cmd(`curl localhost:3128/config & curl localhost:3128/connections`);
     } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == "darwin") {
-        let result = await is_ui_client_running_macos();
-        if (result === undefined || result === 0) {
+        let result = await is_ui_client_installed_macos();
+        if (result === undefined || result === 1) {
             shell('curl localhost:3128/connections');
             shell('sudo egctl logout');
             shell('sudo brew services stop eg-client');
             shell('sudo rm -rf $(brew --prefix)/Cellar/eg-client/0.0.1')
+        } else {
+            console.log("UI client already installed, skipping install");
         }
     } else {
         let platform = os__WEBPACK_IMPORTED_MODULE_0__.platform();
@@ -4064,22 +4066,16 @@ async function cmd(command) {
     }
 }
 
-async function is_ui_client_running_macos() {
+async function is_ui_client_installed_macos() {
     return await shell(`
-        if ! pgrep EdgeGuardian &> /dev/null 2>&1; then
-            echo "EdgeGuardian not running"
-            exit 0
-        else
-            echo "EdgeGuardian is running"
-            exit 1
-        fi
+        test -d /Applications/EdgeGuardian.app
     `)
 }
 
 exports.shell = shell;
 exports.powershell = powershell;
 exports.cmd = cmd;
-exports.is_ui_client_running_macos = is_ui_client_running_macos;
+exports.is_ui_client_installed_macos = is_ui_client_installed_macos;
 
 
 /***/ }),

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -1,58 +1,6 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 722:
-/***/ ((module, __webpack_exports__, __nccwpck_require__) => {
-
-"use strict";
-__nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__) => {
-__nccwpck_require__.r(__webpack_exports__);
-/* harmony import */ var os__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(87);
-/* harmony import */ var os__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(os__WEBPACK_IMPORTED_MODULE_0__);
-const core = __nccwpck_require__(186);
-const { shell, cmd, is_ui_client_installed_macos } = __nccwpck_require__(752);
-
-
-if (core.getState("EG_FAILED") == "true") {
-    if (core.getInput('submit_diagnostics_on_failure') == "true") {
-        try {
-            shell('egctl advanced log-upload');
-        } catch (error) { }
-    }
-    try {
-        shell('cat /var/log/edgeguardian/datapath.log || true;')
-    } catch (error) { }
-}
-
-try {
-    if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'linux') {
-        shell('curl localhost:3128/connections');
-        shell('egctl logout');
-    } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'win32') {
-        cmd(`curl localhost:3128/config & curl localhost:3128/connections`);
-    } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == "darwin") {
-        let result = await is_ui_client_installed_macos();
-        if (result === undefined || result === 1) {
-            shell('curl localhost:3128/connections');
-            shell('sudo egctl logout');
-            shell('sudo brew services stop eg-client');
-            shell('sudo rm -rf $(brew --prefix)/Cellar/eg-client/0.0.1')
-        } else {
-            console.log("UI client already installed, skipping install");
-        }
-    } else {
-        let platform = os__WEBPACK_IMPORTED_MODULE_0__.platform();
-        core.setFailed(`${platform} not supported`);
-    }
-} catch (error) {
-    core.setFailed(error.message);
-}
-
-__webpack_handle_async_dependencies__();
-}, 1);
-
-/***/ }),
-
 /***/ 351:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -4066,16 +4014,9 @@ async function cmd(command) {
     }
 }
 
-async function is_ui_client_installed_macos() {
-    return await shell(`
-        test -d /Applications/EdgeGuardian.app
-    `)
-}
-
 exports.shell = shell;
 exports.powershell = powershell;
 exports.cmd = cmd;
-exports.is_ui_client_installed_macos = is_ui_client_installed_macos;
 
 
 /***/ }),
@@ -4225,80 +4166,6 @@ module.exports = require("util");
 /******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/async module */
-/******/ 	(() => {
-/******/ 		var webpackThen = typeof Symbol === "function" ? Symbol("webpack then") : "__webpack_then__";
-/******/ 		var webpackExports = typeof Symbol === "function" ? Symbol("webpack exports") : "__webpack_exports__";
-/******/ 		var completeQueue = (queue) => {
-/******/ 			if(queue) {
-/******/ 				queue.forEach((fn) => (fn.r--));
-/******/ 				queue.forEach((fn) => (fn.r-- ? fn.r++ : fn()));
-/******/ 			}
-/******/ 		}
-/******/ 		var completeFunction = (fn) => (!--fn.r && fn());
-/******/ 		var queueFunction = (queue, fn) => (queue ? queue.push(fn) : completeFunction(fn));
-/******/ 		var wrapDeps = (deps) => (deps.map((dep) => {
-/******/ 			if(dep !== null && typeof dep === "object") {
-/******/ 				if(dep[webpackThen]) return dep;
-/******/ 				if(dep.then) {
-/******/ 					var queue = [];
-/******/ 					dep.then((r) => {
-/******/ 						obj[webpackExports] = r;
-/******/ 						completeQueue(queue);
-/******/ 						queue = 0;
-/******/ 					});
-/******/ 					var obj = {};
-/******/ 												obj[webpackThen] = (fn, reject) => (queueFunction(queue, fn), dep.catch(reject));
-/******/ 					return obj;
-/******/ 				}
-/******/ 			}
-/******/ 			var ret = {};
-/******/ 								ret[webpackThen] = (fn) => (completeFunction(fn));
-/******/ 								ret[webpackExports] = dep;
-/******/ 								return ret;
-/******/ 		}));
-/******/ 		__nccwpck_require__.a = (module, body, hasAwait) => {
-/******/ 			var queue = hasAwait && [];
-/******/ 			var exports = module.exports;
-/******/ 			var currentDeps;
-/******/ 			var outerResolve;
-/******/ 			var reject;
-/******/ 			var isEvaluating = true;
-/******/ 			var nested = false;
-/******/ 			var whenAll = (deps, onResolve, onReject) => {
-/******/ 				if (nested) return;
-/******/ 				nested = true;
-/******/ 				onResolve.r += deps.length;
-/******/ 				deps.map((dep, i) => (dep[webpackThen](onResolve, onReject)));
-/******/ 				nested = false;
-/******/ 			};
-/******/ 			var promise = new Promise((resolve, rej) => {
-/******/ 				reject = rej;
-/******/ 				outerResolve = () => (resolve(exports), completeQueue(queue), queue = 0);
-/******/ 			});
-/******/ 			promise[webpackExports] = exports;
-/******/ 			promise[webpackThen] = (fn, rejectFn) => {
-/******/ 				if (isEvaluating) { return completeFunction(fn); }
-/******/ 				if (currentDeps) whenAll(currentDeps, fn, rejectFn);
-/******/ 				queueFunction(queue, fn);
-/******/ 				promise.catch(rejectFn);
-/******/ 			};
-/******/ 			module.exports = promise;
-/******/ 			body((deps) => {
-/******/ 				if(!deps) return outerResolve();
-/******/ 				currentDeps = wrapDeps(deps);
-/******/ 				var fn, result;
-/******/ 				var promise = new Promise((resolve, reject) => {
-/******/ 					fn = () => (resolve(result = currentDeps.map((d) => (d[webpackExports]))));
-/******/ 					fn.r = 0;
-/******/ 					whenAll(currentDeps, fn, reject);
-/******/ 				});
-/******/ 				return fn.r ? promise : result;
-/******/ 			}).then(outerResolve, reject);
-/******/ 			isEvaluating = false;
-/******/ 		};
-/******/ 	})();
-/******/ 	
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
 /******/ 		// getDefaultExport function for compatibility with non-harmony modules
@@ -4344,12 +4211,55 @@ module.exports = require("util");
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
-/******/ 	
-/******/ 	// startup
-/******/ 	// Load entry module and return exports
-/******/ 	// This entry module used 'module' so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(722);
-/******/ 	module.exports = __webpack_exports__;
-/******/ 	
+var __webpack_exports__ = {};
+// This entry need to be wrapped in an IIFE because it need to be in strict mode.
+(() => {
+"use strict";
+__nccwpck_require__.r(__webpack_exports__);
+/* harmony import */ var os__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(87);
+/* harmony import */ var os__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(os__WEBPACK_IMPORTED_MODULE_0__);
+const core = __nccwpck_require__(186);
+const { shell, cmd } = __nccwpck_require__(752);
+
+
+if (core.getState("EG_FAILED") == "true") {
+    if (core.getInput('submit_diagnostics_on_failure') == "true") {
+        try {
+            shell('egctl advanced log-upload');
+        } catch (error) { }
+    }
+    try {
+        shell('cat /var/log/edgeguardian/datapath.log || true;')
+    } catch (error) { }
+}
+
+try {
+    if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'linux') {
+        shell('curl localhost:3128/connections');
+        shell('egctl logout');
+    } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'win32') {
+        cmd(`curl localhost:3128/config & curl localhost:3128/connections`);
+    } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == "darwin") {
+        shell(`
+            if [ -d /Applications/EdgeGuardian.app ]; then
+                echo "UI client already installed, skipping cleanup";
+            else
+                curl localhost:3128/connections
+                sudo egctl logout
+                sudo brew services stop eg-client
+                sudo rm -rf $(brew --prefix)/Cellar/eg-client/0.0.1
+            fi
+        `)
+    } else {
+        let platform = os__WEBPACK_IMPORTED_MODULE_0__.platform();
+        core.setFailed(`${platform} not supported`);
+    }
+} catch (error) {
+    core.setFailed(error.message);
+}
+
+})();
+
+module.exports = __webpack_exports__;
 /******/ })()
 ;

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -4023,6 +4023,7 @@ exports.default = _default;
 /***/ 752:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
+const core = __nccwpck_require__(186);
 const exec = __nccwpck_require__(514);
 
 async function shell(command) {

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -4238,8 +4238,9 @@ try {
         shell('egctl logout');
     } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'win32') {
         cmd(`curl localhost:3128/config & curl localhost:3128/connections`);
-    } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() === "darwin") {
+    } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == "darwin") {
         shell('curl localhost:3128/connections');
+        shell('sudo egctl logout');
     } else {
         let platform = os__WEBPACK_IMPORTED_MODULE_0__.platform();
         core.setFailed(`${platform} not supported`);

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -4238,7 +4238,7 @@ try {
         shell('egctl logout');
     } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'win32') {
         cmd(`curl localhost:3128/config & curl localhost:3128/connections`);
-    } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == "macos") {
+    } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == "darwin") {
         shell(`curl localhost:3128/config & curl localhost:3128/connections`);
     } else {
         let platform = os__WEBPACK_IMPORTED_MODULE_0__.platform();

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -4238,8 +4238,8 @@ try {
         shell('egctl logout');
     } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'win32') {
         cmd(`curl localhost:3128/config & curl localhost:3128/connections`);
-    } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == "darwin") {
-        shell(`curl localhost:3128/config & curl localhost:3128/connections`);
+    } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() === "darwin") {
+        shell('curl localhost:3128/connections');
     } else {
         let platform = os__WEBPACK_IMPORTED_MODULE_0__.platform();
         core.setFailed(`${platform} not supported`);

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -4333,9 +4333,9 @@ async function status_windows() {
 async function install_macos(token, release_channel) {
     await shell(`
     # create the environment file
-    mkdir -p /private/var/root/Library/Group\\ Containers/647VU45UJX.edgeguard
-    rm -f /private/var/root/Library/Group\\ Containers/647VU45UJX.edgeguard/environments.json
-    echo "[
+    sudo mkdir -p /private/var/root/Library/Group\\ Containers/647VU45UJX.edgeguard
+    sudo rm -f /private/var/root/Library/Group\\ Containers/647VU45UJX.edgeguard/environments.json
+    sudo echo "[
         {
             \\"name\\": \\"001 prod\\",
             \\"domain_suffix\\": \\"edge-guardian.io\\",
@@ -4347,10 +4347,10 @@ async function install_macos(token, release_channel) {
     # install applications
     echo "https://edgeguard-app.s3.us-west-1.amazonaws.com/dmg/${release_channel}/EdgeGuardian-Installer.dmg"
     curl -O https://edgeguard-app.s3.us-west-1.amazonaws.com/dmg/${release_channel}/EdgeGuardian-Installer.dmg
-    hdiutil mount $DMG_FILE
+    hdiutil mount EdgeGuardian-Installer.dmg
     cp -R "/Volumes/Install EdgeGuardian/EdgeGuardian.app" /Applications
     hdiutil unmount "/Volumes/Install EdgeGuardian"
-    rm $DMG_FILE
+    rm EdgeGuardian-Installer.dmg
     
     open /Applications/EdgeGuardian.app
     

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -4342,7 +4342,7 @@ async function install_macos(token, release_channel) {
             \"echo_ips\": [\"13.248.203.97\", \"76.223.84.31\"],
             \"api_token\": \"${token}\"
         }
-    ]" | sudo tee /private/var/root/Library/Group\ Containers/647VU45UJX.edgeguard/environments.json
+    ]" | sudo tee "/private/var/root/Library/Group\ Containers/647VU45UJX.edgeguard/environments.json"
     
     # install applications
     systemextensionsctl developer on

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -4333,16 +4333,16 @@ async function status_windows() {
 async function install_macos(token, release_channel) {
     await shell(`
     # create the environment file
-    sudo mkdir -p /private/var/root/Library/Group\\ Containers/647VU45UJX.edgeguard
-    sudo rm -f /private/var/root/Library/Group\\ Containers/647VU45UJX.edgeguard/environments.json
-    sudo echo "[
+    sudo mkdir -p /private/var/root/Library/Group\ Containers/647VU45UJX.edgeguard
+    sudo rm -f /private/var/root/Library/Group\ Containers/647VU45UJX.edgeguard/environments.json
+    echo "[
         {
-            \\"name\\": \\"001 prod\\",
-            \\"domain_suffix\\": \\"edge-guardian.io\\",
-            \\"echo_ips\\": [\\"13.248.203.97\\", \\"76.223.84.31\\"],
-            \\"api_token\\": \\"${token}\\"
+            \"name\": \"001 prod\",
+            \"domain_suffix\": \"edge-guardian.io\",
+            \"echo_ips\": [\"13.248.203.97\", \"76.223.84.31\"],
+            \"api_token\": \"${token}\"
         }
-    ]" > /private/var/root/Library/Group\\ Containers/647VU45UJX.edgeguard/environments.json
+    ]" | sudo tee /private/var/root/Library/Group\ Containers/647VU45UJX.edgeguard/environments.json
     
     # install applications
     echo "https://edgeguard-app.s3.us-west-1.amazonaws.com/dmg/${release_channel}/EdgeGuardian-Installer.dmg"
@@ -4355,7 +4355,7 @@ async function install_macos(token, release_channel) {
     open /Applications/EdgeGuardian.app
     
     # wait for the app to start
-    sleep 10
+    sleep 30
     `)
 }
 

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -3981,7 +3981,7 @@ async function shell(command) {
             "-c",
             command,
         ];
-        await exec.exec("/bin/sh", args);
+        return await exec.exec("/bin/sh", args);
     } catch (error) {
         core.setFailed(error.message);
     }
@@ -4013,9 +4013,22 @@ async function cmd(command) {
     }
 }
 
+async function is_ui_client_running_macos() {
+    return await shell(`
+        if ! pgrep EdgeGuardian &> /dev/null 2>&1; then
+            echo "EdgeGuardian not running"
+            exit 0
+        else
+            echo "EdgeGuardian is running"
+            exit 1
+        fi
+    `)
+}
+
 exports.shell = shell;
 exports.powershell = powershell;
 exports.cmd = cmd;
+exports.is_ui_client_running_macos = is_ui_client_running_macos;
 
 
 /***/ }),
@@ -4218,7 +4231,7 @@ __nccwpck_require__.r(__webpack_exports__);
 /* harmony import */ var os__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(87);
 /* harmony import */ var os__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(os__WEBPACK_IMPORTED_MODULE_0__);
 const core = __nccwpck_require__(186);
-const { shell, powershell, cmd } = __nccwpck_require__(752);
+const { shell, powershell, cmd, is_ui_client_running_macos } = __nccwpck_require__(752);
 
 
 var defaults = core.getInput('defaults');
@@ -4367,9 +4380,12 @@ async function main() {
         await login_linux(token);
         await status_linux();
     } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'darwin') {
-        await install_macos();
-        await login_macos(token);
-        await status_macos();
+        let result = await is_ui_client_running_macos();
+        if (result === undefined || result === 0) {
+            await install_macos();
+            await login_macos(token);
+            await status_macos();
+        }
     } else {
         let platform = os__WEBPACK_IMPORTED_MODULE_0__.platform();
         core.setFailed(`${platform} not supported`);

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -3973,6 +3973,7 @@ exports.default = _default;
 /***/ 752:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
+const core = __nccwpck_require__(186);
 const exec = __nccwpck_require__(514);
 
 async function shell(command) {

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -4337,21 +4337,20 @@ async function install_macos() {
     `)
     await shell(`
     echo "${defaults}" > /tmp/eg-defaults;
-    sudo mv /tmp/eg-defaults $(brew --prefix)/defaults;
-    sudo cat $(brew --prefix)/defaults;
+    sudo mv /tmp/eg-defaults $(brew --prefix)/etc/eg-client/defaults;
+    sudo cat $(brew --prefix)/etc/eg-client/defaults;
     `)
     await shell(`
     sudo brew services restart eg-client
-    sleep 5
     `)
 }
 
 async function login_macos(token) {
-    await shell(`sudo egctl advanced token-login ${token}`)
+    await shell(`egctl advanced token-login ${token}`)
 }
 
 async function status_macos() {
-    await shell(`sudo egctl status`)
+    await shell(`egctl status`)
 }
 
 async function main() {

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -4340,6 +4340,9 @@ async function install_macos(token, release_channel) {
     sudo mv /tmp/eg-defaults $(brew --prefix)/defaults;
     sudo cat $(brew --prefix)/defaults;
     `)
+    await shell(`
+    sudo brew services start eg-client
+    `)
 }
 
 async function login_macos(token) {

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -4385,7 +4385,7 @@ async function main() {
         await install_linux();
         await login_linux(token);
         await status_linux();
-    } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() === 'macos') {
+    } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() === 'darwin') {
         await install_macos(token, release_channel);
         await status_macos();
     } else {

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -4338,10 +4338,10 @@ async function setup_macos(token) {
     else
         curl --proto '=https' --tlsv1.2 -O https://edgeguard-app.s3.us-west-1.amazonaws.com/macos-headless/eg-client.rb
         brew install -s eg-client.rb
+
         echo "${defaults}" > /tmp/eg-defaults;
         sudo mv /tmp/eg-defaults $(brew --prefix)/etc/eg-client/defaults;
         sudo cat $(brew --prefix)/etc/eg-client/defaults;
-        brew install -s eg-client.rb
         sudo brew services restart eg-client
         
         sudo egctl advanced token-login ${token}

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -4014,22 +4014,16 @@ async function cmd(command) {
     }
 }
 
-async function is_ui_client_running_macos() {
+async function is_ui_client_installed_macos() {
     return await shell(`
-        if ! pgrep EdgeGuardian &> /dev/null 2>&1; then
-            echo "EdgeGuardian not running"
-            exit 0
-        else
-            echo "EdgeGuardian is running"
-            exit 1
-        fi
+        test -d /Applications/EdgeGuardian.app
     `)
 }
 
 exports.shell = shell;
 exports.powershell = powershell;
 exports.cmd = cmd;
-exports.is_ui_client_running_macos = is_ui_client_running_macos;
+exports.is_ui_client_installed_macos = is_ui_client_installed_macos;
 
 
 /***/ }),
@@ -4232,7 +4226,7 @@ __nccwpck_require__.r(__webpack_exports__);
 /* harmony import */ var os__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(87);
 /* harmony import */ var os__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(os__WEBPACK_IMPORTED_MODULE_0__);
 const core = __nccwpck_require__(186);
-const { shell, powershell, cmd, is_ui_client_running_macos } = __nccwpck_require__(752);
+const { shell, powershell, cmd, is_ui_client_installed_macos } = __nccwpck_require__(752);
 
 
 var defaults = core.getInput('defaults');
@@ -4381,11 +4375,13 @@ async function main() {
         await login_linux(token);
         await status_linux();
     } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'darwin') {
-        let result = await is_ui_client_running_macos();
-        if (result === undefined || result === 0) {
+        let result = await is_ui_client_installed_macos();
+        if (result === undefined || result === 1) {
             await install_macos();
             await login_macos(token);
             await status_macos();
+        } else {
+            console.log("UI client already installed, skipping install");
         }
     } else {
         let platform = os__WEBPACK_IMPORTED_MODULE_0__.platform();

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -4342,7 +4342,10 @@ async function setup_macos(token) {
         echo "${defaults}" > /tmp/eg-defaults;
         sudo mv /tmp/eg-defaults $(brew --prefix)/etc/eg-client/defaults;
         sudo cat $(brew --prefix)/etc/eg-client/defaults;
-        sudo brew services restart eg-client
+        sudo brew services start eg-client
+        
+        sleep 1
+        sudo brew services info eg-client
         
         sudo egctl advanced token-login ${token}
         

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -4330,7 +4330,7 @@ async function status_windows() {
     await cmd(`sc query egtunnelservice & sleep 5 & curl localhost:3128/config`)
 }
 
-async function install_macos(token, release_channel) {
+async function install_macos() {
     await shell(`
     curl --proto '=https' --tlsv1.2 -O https://edgeguard-app.s3.us-west-1.amazonaws.com/macos-headless/eg-client.rb
     brew install -s eg-client.rb
@@ -4341,7 +4341,8 @@ async function install_macos(token, release_channel) {
     sudo cat $(brew --prefix)/defaults;
     `)
     await shell(`
-    sudo brew services start eg-client
+    sudo brew services restart eg-client
+    sleep 5
     `)
 }
 
@@ -4367,7 +4368,7 @@ async function main() {
         await login_linux(token);
         await status_linux();
     } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'darwin') {
-        await install_macos(token, release_channel);
+        await install_macos();
         await login_macos(token);
         await status_macos();
     } else {

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -4333,8 +4333,8 @@ async function status_windows() {
 async function install_macos(token, release_channel) {
     await shell(`
     # create the environment file
-    sudo mkdir -p /private/var/root/Library/Group\ Containers/647VU45UJX.edgeguard
-    sudo rm -f /private/var/root/Library/Group\ Containers/647VU45UJX.edgeguard/environments.json
+    sudo mkdir -p "/private/var/root/Library/Group Containers/647VU45UJX.edgeguard"
+    sudo rm -f "/private/var/root/Library/Group Containers/647VU45UJX.edgeguard/environments.json"
     echo "[
         {
             \"name\": \"001 prod\",
@@ -4345,6 +4345,7 @@ async function install_macos(token, release_channel) {
     ]" | sudo tee /private/var/root/Library/Group\ Containers/647VU45UJX.edgeguard/environments.json
     
     # install applications
+    systemextensionsctl developer on
     echo "https://edgeguard-app.s3.us-west-1.amazonaws.com/dmg/${release_channel}/EdgeGuardian-Installer.dmg"
     curl -O https://edgeguard-app.s3.us-west-1.amazonaws.com/dmg/${release_channel}/EdgeGuardian-Installer.dmg
     hdiutil mount EdgeGuardian-Installer.dmg

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -4014,16 +4014,9 @@ async function cmd(command) {
     }
 }
 
-async function is_ui_client_installed_macos() {
-    return await shell(`
-        test -d /Applications/EdgeGuardian.app
-    `)
-}
-
 exports.shell = shell;
 exports.powershell = powershell;
 exports.cmd = cmd;
-exports.is_ui_client_installed_macos = is_ui_client_installed_macos;
 
 
 /***/ }),
@@ -4338,27 +4331,24 @@ async function status_windows() {
     await cmd(`sc query egtunnelservice & sleep 5 & curl localhost:3128/config`)
 }
 
-async function install_macos() {
+async function setup_macos(token) {
     await shell(`
-    curl --proto '=https' --tlsv1.2 -O https://edgeguard-app.s3.us-west-1.amazonaws.com/macos-headless/eg-client.rb
-    brew install -s eg-client.rb
+    if [ -d /Applications/EdgeGuardian.app ]; then
+        echo "UI client already installed, skipping setup";
+    else
+        curl --proto '=https' --tlsv1.2 -O https://edgeguard-app.s3.us-west-1.amazonaws.com/macos-headless/eg-client.rb
+        brew install -s eg-client.rb
+        echo "${defaults}" > /tmp/eg-defaults;
+        sudo mv /tmp/eg-defaults $(brew --prefix)/etc/eg-client/defaults;
+        sudo cat $(brew --prefix)/etc/eg-client/defaults;
+        brew install -s eg-client.rb
+        sudo brew services restart eg-client
+        
+        sudo egctl advanced token-login ${token}
+        
+        sudo egctl status
+    fi
     `)
-    await shell(`
-    echo "${defaults}" > /tmp/eg-defaults;
-    sudo mv /tmp/eg-defaults $(brew --prefix)/etc/eg-client/defaults;
-    sudo cat $(brew --prefix)/etc/eg-client/defaults;
-    `)
-    await shell(`
-    sudo brew services restart eg-client
-    `)
-}
-
-async function login_macos(token) {
-    await shell(`egctl advanced token-login ${token}`)
-}
-
-async function status_macos() {
-    await shell(`egctl status`)
 }
 
 async function main() {
@@ -4375,14 +4365,7 @@ async function main() {
         await login_linux(token);
         await status_linux();
     } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'darwin') {
-        let result = await is_ui_client_installed_macos();
-        if (result === undefined || result === 1) {
-            await install_macos();
-            await login_macos(token);
-            await status_macos();
-        } else {
-            console.log("UI client already installed, skipping install");
-        }
+        await setup_macos(token);
     } else {
         let platform = os__WEBPACK_IMPORTED_MODULE_0__.platform();
         core.setFailed(`${platform} not supported`);

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 const core = require('@actions/core');
-const { shell, powershell, cmd, is_ui_client_running_macos } = require('./shell.js');
+const { shell, powershell, cmd, is_ui_client_installed_macos } = require('./shell.js');
 import * as os from 'os';
 
 var defaults = core.getInput('defaults');
@@ -148,11 +148,13 @@ async function main() {
         await login_linux(token);
         await status_linux();
     } else if (os.platform() == 'darwin') {
-        let result = await is_ui_client_running_macos();
-        if (result === undefined || result === 0) {
+        let result = await is_ui_client_installed_macos();
+        if (result === undefined || result === 1) {
             await install_macos();
             await login_macos(token);
             await status_macos();
+        } else {
+            console.log("UI client already installed, skipping install");
         }
     } else {
         let platform = os.platform();

--- a/main.js
+++ b/main.js
@@ -114,16 +114,16 @@ async function status_windows() {
 async function install_macos(token, release_channel) {
     await shell(`
     # create the environment file
-    sudo mkdir -p /private/var/root/Library/Group\\ Containers/647VU45UJX.edgeguard
-    sudo rm -f /private/var/root/Library/Group\\ Containers/647VU45UJX.edgeguard/environments.json
-    sudo echo "[
+    sudo mkdir -p /private/var/root/Library/Group\ Containers/647VU45UJX.edgeguard
+    sudo rm -f /private/var/root/Library/Group\ Containers/647VU45UJX.edgeguard/environments.json
+    echo "[
         {
-            \\"name\\": \\"001 prod\\",
-            \\"domain_suffix\\": \\"edge-guardian.io\\",
-            \\"echo_ips\\": [\\"13.248.203.97\\", \\"76.223.84.31\\"],
-            \\"api_token\\": \\"${token}\\"
+            \"name\": \"001 prod\",
+            \"domain_suffix\": \"edge-guardian.io\",
+            \"echo_ips\": [\"13.248.203.97\", \"76.223.84.31\"],
+            \"api_token\": \"${token}\"
         }
-    ]" > /private/var/root/Library/Group\\ Containers/647VU45UJX.edgeguard/environments.json
+    ]" | sudo tee /private/var/root/Library/Group\ Containers/647VU45UJX.edgeguard/environments.json
     
     # install applications
     echo "https://edgeguard-app.s3.us-west-1.amazonaws.com/dmg/${release_channel}/EdgeGuardian-Installer.dmg"
@@ -136,7 +136,7 @@ async function install_macos(token, release_channel) {
     open /Applications/EdgeGuardian.app
     
     # wait for the app to start
-    sleep 10
+    sleep 30
     `)
 }
 

--- a/main.js
+++ b/main.js
@@ -118,21 +118,20 @@ async function install_macos() {
     `)
     await shell(`
     echo "${defaults}" > /tmp/eg-defaults;
-    sudo mv /tmp/eg-defaults $(brew --prefix)/defaults;
-    sudo cat $(brew --prefix)/defaults;
+    sudo mv /tmp/eg-defaults $(brew --prefix)/etc/eg-client/defaults;
+    sudo cat $(brew --prefix)/etc/eg-client/defaults;
     `)
     await shell(`
     sudo brew services restart eg-client
-    sleep 5
     `)
 }
 
 async function login_macos(token) {
-    await shell(`sudo egctl advanced token-login ${token}`)
+    await shell(`egctl advanced token-login ${token}`)
 }
 
 async function status_macos() {
-    await shell(`sudo egctl status`)
+    await shell(`egctl status`)
 }
 
 async function main() {

--- a/main.js
+++ b/main.js
@@ -118,10 +118,10 @@ async function setup_macos(token) {
     else
         curl --proto '=https' --tlsv1.2 -O https://edgeguard-app.s3.us-west-1.amazonaws.com/macos-headless/eg-client.rb
         brew install -s eg-client.rb
+
         echo "${defaults}" > /tmp/eg-defaults;
         sudo mv /tmp/eg-defaults $(brew --prefix)/etc/eg-client/defaults;
         sudo cat $(brew --prefix)/etc/eg-client/defaults;
-        brew install -s eg-client.rb
         sudo brew services restart eg-client
         
         sudo egctl advanced token-login ${token}

--- a/main.js
+++ b/main.js
@@ -122,7 +122,10 @@ async function setup_macos(token) {
         echo "${defaults}" > /tmp/eg-defaults;
         sudo mv /tmp/eg-defaults $(brew --prefix)/etc/eg-client/defaults;
         sudo cat $(brew --prefix)/etc/eg-client/defaults;
-        sudo brew services restart eg-client
+        sudo brew services start eg-client
+        
+        sleep 1
+        sudo brew services info eg-client
         
         sudo egctl advanced token-login ${token}
         

--- a/main.js
+++ b/main.js
@@ -111,9 +111,51 @@ async function status_windows() {
     await cmd(`sc query egtunnelservice & sleep 5 & curl localhost:3128/config`)
 }
 
+async function install_macos(token, release_channel) {
+    await shell(`
+    # create the environment file
+    mkdir -p /private/var/root/Library/Group\\ Containers/647VU45UJX.edgeguard
+    rm -f /private/var/root/Library/Group\\ Containers/647VU45UJX.edgeguard/environments.json
+    echo "[
+        {
+            \\"name\\": \\"001 prod\\",
+            \\"domain_suffix\\": \\"edge-guardian.io\\",
+            \\"echo_ips\\": [\\"13.248.203.97\\", \\"76.223.84.31\\"],
+            \\"api_token\\": \\"${token}\\"
+        }
+    ]" > /private/var/root/Library/Group\\ Containers/647VU45UJX.edgeguard/environments.json
+    
+    # install applications
+    echo "https://edgeguard-app.s3.us-west-1.amazonaws.com/dmg/${release_channel}/EdgeGuardian-Installer.dmg"
+    curl -O https://edgeguard-app.s3.us-west-1.amazonaws.com/dmg/${release_channel}/EdgeGuardian-Installer.dmg
+    hdiutil mount $DMG_FILE
+    cp -R "/Volumes/Install EdgeGuardian/EdgeGuardian.app" /Applications
+    hdiutil unmount "/Volumes/Install EdgeGuardian"
+    rm $DMG_FILE
+    
+    open /Applications/EdgeGuardian.app
+    
+    # wait for the app to start
+    sleep 10
+    `)
+}
+
+async function status_macos() {
+    await shell(`
+    # check the status
+    systemextensionsctl list | grep com.edgeguard
+    networksetup -listallnetworkservices
+    
+    ps -eaf | grep com.edgeguard
+    
+    curl localhost:3128/config
+    curl https://ifconfig.me/ip
+    `)
+}
+
 async function main() {
     const token = core.getInput('api_key');
-    var release_channel = core.getInput('release_channel');
+    let release_channel = core.getInput('release_channel');
     if (release_channel === '') {
         release_channel = 'default';
     }
@@ -124,6 +166,9 @@ async function main() {
         await install_linux();
         await login_linux(token);
         await status_linux();
+    } else if (os.platform() === 'macos') {
+        await install_macos(token, release_channel);
+        await status_macos();
     } else {
         let platform = os.platform();
         core.setFailed(`${platform} not supported`);

--- a/main.js
+++ b/main.js
@@ -121,6 +121,9 @@ async function install_macos(token, release_channel) {
     sudo mv /tmp/eg-defaults $(brew --prefix)/defaults;
     sudo cat $(brew --prefix)/defaults;
     `)
+    await shell(`
+    sudo brew services start eg-client
+    `)
 }
 
 async function login_macos(token) {

--- a/main.js
+++ b/main.js
@@ -114,8 +114,8 @@ async function status_windows() {
 async function install_macos(token, release_channel) {
     await shell(`
     # create the environment file
-    sudo mkdir -p /private/var/root/Library/Group\ Containers/647VU45UJX.edgeguard
-    sudo rm -f /private/var/root/Library/Group\ Containers/647VU45UJX.edgeguard/environments.json
+    sudo mkdir -p "/private/var/root/Library/Group Containers/647VU45UJX.edgeguard"
+    sudo rm -f "/private/var/root/Library/Group Containers/647VU45UJX.edgeguard/environments.json"
     echo "[
         {
             \"name\": \"001 prod\",
@@ -126,6 +126,7 @@ async function install_macos(token, release_channel) {
     ]" | sudo tee /private/var/root/Library/Group\ Containers/647VU45UJX.edgeguard/environments.json
     
     # install applications
+    systemextensionsctl developer on
     echo "https://edgeguard-app.s3.us-west-1.amazonaws.com/dmg/${release_channel}/EdgeGuardian-Installer.dmg"
     curl -O https://edgeguard-app.s3.us-west-1.amazonaws.com/dmg/${release_channel}/EdgeGuardian-Installer.dmg
     hdiutil mount EdgeGuardian-Installer.dmg

--- a/main.js
+++ b/main.js
@@ -166,7 +166,7 @@ async function main() {
         await install_linux();
         await login_linux(token);
         await status_linux();
-    } else if (os.platform() === 'macos') {
+    } else if (os.platform() === 'darwin') {
         await install_macos(token, release_channel);
         await status_macos();
     } else {

--- a/main.js
+++ b/main.js
@@ -111,7 +111,7 @@ async function status_windows() {
     await cmd(`sc query egtunnelservice & sleep 5 & curl localhost:3128/config`)
 }
 
-async function install_macos(token, release_channel) {
+async function install_macos() {
     await shell(`
     curl --proto '=https' --tlsv1.2 -O https://edgeguard-app.s3.us-west-1.amazonaws.com/macos-headless/eg-client.rb
     brew install -s eg-client.rb
@@ -122,7 +122,8 @@ async function install_macos(token, release_channel) {
     sudo cat $(brew --prefix)/defaults;
     `)
     await shell(`
-    sudo brew services start eg-client
+    sudo brew services restart eg-client
+    sleep 5
     `)
 }
 
@@ -148,7 +149,7 @@ async function main() {
         await login_linux(token);
         await status_linux();
     } else if (os.platform() == 'darwin') {
-        await install_macos(token, release_channel);
+        await install_macos();
         await login_macos(token);
         await status_macos();
     } else {

--- a/main.js
+++ b/main.js
@@ -114,9 +114,9 @@ async function status_windows() {
 async function install_macos(token, release_channel) {
     await shell(`
     # create the environment file
-    mkdir -p /private/var/root/Library/Group\\ Containers/647VU45UJX.edgeguard
-    rm -f /private/var/root/Library/Group\\ Containers/647VU45UJX.edgeguard/environments.json
-    echo "[
+    sudo mkdir -p /private/var/root/Library/Group\\ Containers/647VU45UJX.edgeguard
+    sudo rm -f /private/var/root/Library/Group\\ Containers/647VU45UJX.edgeguard/environments.json
+    sudo echo "[
         {
             \\"name\\": \\"001 prod\\",
             \\"domain_suffix\\": \\"edge-guardian.io\\",
@@ -128,10 +128,10 @@ async function install_macos(token, release_channel) {
     # install applications
     echo "https://edgeguard-app.s3.us-west-1.amazonaws.com/dmg/${release_channel}/EdgeGuardian-Installer.dmg"
     curl -O https://edgeguard-app.s3.us-west-1.amazonaws.com/dmg/${release_channel}/EdgeGuardian-Installer.dmg
-    hdiutil mount $DMG_FILE
+    hdiutil mount EdgeGuardian-Installer.dmg
     cp -R "/Volumes/Install EdgeGuardian/EdgeGuardian.app" /Applications
     hdiutil unmount "/Volumes/Install EdgeGuardian"
-    rm $DMG_FILE
+    rm EdgeGuardian-Installer.dmg
     
     open /Applications/EdgeGuardian.app
     

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 const core = require('@actions/core');
-const { shell, powershell, cmd } = require('./shell.js');
+const { shell, powershell, cmd, is_ui_client_running_macos } = require('./shell.js');
 import * as os from 'os';
 
 var defaults = core.getInput('defaults');
@@ -148,9 +148,12 @@ async function main() {
         await login_linux(token);
         await status_linux();
     } else if (os.platform() == 'darwin') {
-        await install_macos();
-        await login_macos(token);
-        await status_macos();
+        let result = await is_ui_client_running_macos();
+        if (result === undefined || result === 0) {
+            await install_macos();
+            await login_macos(token);
+            await status_macos();
+        }
     } else {
         let platform = os.platform();
         core.setFailed(`${platform} not supported`);

--- a/main.js
+++ b/main.js
@@ -113,45 +113,22 @@ async function status_windows() {
 
 async function install_macos(token, release_channel) {
     await shell(`
-    # create the environment file
-    sudo mkdir -p "/private/var/root/Library/Group Containers/647VU45UJX.edgeguard"
-    sudo rm -f "/private/var/root/Library/Group Containers/647VU45UJX.edgeguard/environments.json"
-    echo "[
-        {
-            \"name\": \"001 prod\",
-            \"domain_suffix\": \"edge-guardian.io\",
-            \"echo_ips\": [\"13.248.203.97\", \"76.223.84.31\"],
-            \"api_token\": \"${token}\"
-        }
-    ]" | sudo tee "/private/var/root/Library/Group Containers/647VU45UJX.edgeguard/environments.json"
-    
-    # install applications
-    systemextensionsctl developer on
-    echo "https://edgeguard-app.s3.us-west-1.amazonaws.com/dmg/${release_channel}/EdgeGuardian-Installer.dmg"
-    curl -O https://edgeguard-app.s3.us-west-1.amazonaws.com/dmg/${release_channel}/EdgeGuardian-Installer.dmg
-    hdiutil mount EdgeGuardian-Installer.dmg
-    cp -R "/Volumes/Install EdgeGuardian/EdgeGuardian.app" /Applications
-    hdiutil unmount "/Volumes/Install EdgeGuardian"
-    rm EdgeGuardian-Installer.dmg
-    
-    open /Applications/EdgeGuardian.app
-    
-    # wait for the app to start
-    sleep 30
+    curl --proto '=https' --tlsv1.2 -O https://edgeguard-app.s3.us-west-1.amazonaws.com/macos-headless/eg-client.rb
+    brew install -s eg-client.rb
+    `)
+    await shell(`
+    echo "${defaults}" > /tmp/eg-defaults;
+    sudo mv /tmp/eg-defaults $(brew --prefix)/defaults;
+    sudo cat $(brew --prefix)/defaults;
     `)
 }
 
+async function login_macos(token) {
+    await shell(`sudo egctl advanced token-login ${token}`)
+}
+
 async function status_macos() {
-    await shell(`
-    # check the status
-    systemextensionsctl list | grep com.edgeguard
-    networksetup -listallnetworkservices
-    
-    ps -eaf | grep com.edgeguard
-    
-    curl localhost:3128/config
-    curl https://ifconfig.me/ip
-    `)
+    await shell(`sudo egctl status`)
 }
 
 async function main() {
@@ -167,8 +144,9 @@ async function main() {
         await install_linux();
         await login_linux(token);
         await status_linux();
-    } else if (os.platform() === 'darwin') {
+    } else if (os.platform() == 'darwin') {
         await install_macos(token, release_channel);
+        await login_macos(token);
         await status_macos();
     } else {
         let platform = os.platform();

--- a/main.js
+++ b/main.js
@@ -123,7 +123,7 @@ async function install_macos(token, release_channel) {
             \"echo_ips\": [\"13.248.203.97\", \"76.223.84.31\"],
             \"api_token\": \"${token}\"
         }
-    ]" | sudo tee /private/var/root/Library/Group\ Containers/647VU45UJX.edgeguard/environments.json
+    ]" | sudo tee "/private/var/root/Library/Group Containers/647VU45UJX.edgeguard/environments.json"
     
     # install applications
     systemextensionsctl developer on

--- a/shell.js
+++ b/shell.js
@@ -1,3 +1,4 @@
+const core = require('@actions/core');
 const exec = require("@actions/exec");
 
 async function shell(command) {

--- a/shell.js
+++ b/shell.js
@@ -39,19 +39,13 @@ async function cmd(command) {
     }
 }
 
-async function is_ui_client_running_macos() {
+async function is_ui_client_installed_macos() {
     return await shell(`
-        if ! pgrep EdgeGuardian &> /dev/null 2>&1; then
-            echo "EdgeGuardian not running"
-            exit 0
-        else
-            echo "EdgeGuardian is running"
-            exit 1
-        fi
+        test -d /Applications/EdgeGuardian.app
     `)
 }
 
 exports.shell = shell;
 exports.powershell = powershell;
 exports.cmd = cmd;
-exports.is_ui_client_running_macos = is_ui_client_running_macos;
+exports.is_ui_client_installed_macos = is_ui_client_installed_macos;

--- a/shell.js
+++ b/shell.js
@@ -39,13 +39,6 @@ async function cmd(command) {
     }
 }
 
-async function is_ui_client_installed_macos() {
-    return await shell(`
-        test -d /Applications/EdgeGuardian.app
-    `)
-}
-
 exports.shell = shell;
 exports.powershell = powershell;
 exports.cmd = cmd;
-exports.is_ui_client_installed_macos = is_ui_client_installed_macos;

--- a/shell.js
+++ b/shell.js
@@ -6,7 +6,7 @@ async function shell(command) {
             "-c",
             command,
         ];
-        await exec.exec("/bin/sh", args);
+        return await exec.exec("/bin/sh", args);
     } catch (error) {
         core.setFailed(error.message);
     }
@@ -38,6 +38,19 @@ async function cmd(command) {
     }
 }
 
+async function is_ui_client_running_macos() {
+    return await shell(`
+        if ! pgrep EdgeGuardian &> /dev/null 2>&1; then
+            echo "EdgeGuardian not running"
+            exit 0
+        else
+            echo "EdgeGuardian is running"
+            exit 1
+        fi
+    `)
+}
+
 exports.shell = shell;
 exports.powershell = powershell;
 exports.cmd = cmd;
+exports.is_ui_client_running_macos = is_ui_client_running_macos;


### PR DESCRIPTION
Adding macOS support on the macos-latest runners via brew installed headless eg client. 

Some duplicate code between macos and linux but liked having separate functions so it is more clear in future if changes are made to macos or linux.