### PR TITLE
ignore errors during cleanup

### DIFF
--- a/cleanup.js
+++ b/cleanup.js
@@ -2,23 +2,25 @@ const core = require('@actions/core');
 const { shell, cmd } = require('./shell.js');
 import * as os from 'os';
 
+let ignore_errors = true;
+
 if (core.getState("EG_FAILED") == "true") {
     if (core.getInput('submit_diagnostics_on_failure') == "true") {
         try {
-            shell('egctl advanced log-upload');
+            shell('egctl advanced log-upload', ignore_errors);
         } catch (error) { }
     }
     try {
-        shell('cat /var/log/edgeguardian/datapath.log || true;')
+        shell('cat /var/log/edgeguardian/datapath.log', ignore_errors)
     } catch (error) { }
 }
 
 try {
     if (os.platform() == 'linux') {
-        shell('curl localhost:3128/connections');
-        shell('egctl logout');
+        shell('curl localhost:3128/connections', ignore_errors);
+        shell('egctl logout', ignore_errors);
     } else if (os.platform() == 'win32') {
-        cmd(`curl localhost:3128/config & curl localhost:3128/connections`);
+        cmd(`curl localhost:3128/config & curl localhost:3128/connections`, ignore_errors);
     } else if (os.platform() == "darwin") {
         shell(`
             if [ -d /Applications/EdgeGuardian.app ]; then
@@ -30,7 +32,7 @@ try {
                 sudo rm -rf $(brew --prefix)/Cellar/eg-client/0.0.1
                 brew cleanup
             fi
-        `)
+        `, ignore_errors)
     } else {
         let platform = os.platform();
         core.setFailed(`${platform} not supported`);

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -3976,7 +3976,7 @@ exports.default = _default;
 const core = __nccwpck_require__(186);
 const exec = __nccwpck_require__(514);
 
-async function shell(command) {
+async function shell(command, ignore_errors = false) {
     try {
         const args = [
             "-c",
@@ -3984,11 +3984,13 @@ async function shell(command) {
         ];
         return await exec.exec("/bin/sh", args);
     } catch (error) {
-        core.setFailed(error.message);
+        if (!ignore_errors) {
+            core.setFailed(error.message);
+        }
     }
 }
 
-async function powershell(command) {
+async function powershell(command, ignore_errors = false) {
     try {
         const args = [
             "-ExecutionPolicy",
@@ -3998,11 +4000,13 @@ async function powershell(command) {
         ];
         await exec.exec("powershell.exe", args);
     } catch (error) {
-        core.setFailed(error.message);
+        if (!ignore_errors) {
+            core.setFailed(error.message);
+        }
     }
 }
 
-async function cmd(command) {
+async function cmd(command, ignore_errors = false) {
     try {
         const args = [
             "/c",
@@ -4010,7 +4014,9 @@ async function cmd(command) {
         ];
         await exec.exec("cmd.exe", args);
     } catch (error) {
-        core.setFailed(error.message);
+        if (!ignore_errors) {
+            core.setFailed(error.message);
+        }
     }
 }
 
@@ -4222,23 +4228,25 @@ const core = __nccwpck_require__(186);
 const { shell, cmd } = __nccwpck_require__(752);
 
 
+let ignore_errors = true;
+
 if (core.getState("EG_FAILED") == "true") {
     if (core.getInput('submit_diagnostics_on_failure') == "true") {
         try {
-            shell('egctl advanced log-upload');
+            shell('egctl advanced log-upload', ignore_errors);
         } catch (error) { }
     }
     try {
-        shell('cat /var/log/edgeguardian/datapath.log || true;')
+        shell('cat /var/log/edgeguardian/datapath.log', ignore_errors)
     } catch (error) { }
 }
 
 try {
     if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'linux') {
-        shell('curl localhost:3128/connections');
-        shell('egctl logout');
+        shell('curl localhost:3128/connections', ignore_errors);
+        shell('egctl logout', ignore_errors);
     } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == 'win32') {
-        cmd(`curl localhost:3128/config & curl localhost:3128/connections`);
+        cmd(`curl localhost:3128/config & curl localhost:3128/connections`, ignore_errors);
     } else if (os__WEBPACK_IMPORTED_MODULE_0__.platform() == "darwin") {
         shell(`
             if [ -d /Applications/EdgeGuardian.app ]; then
@@ -4250,7 +4258,7 @@ try {
                 sudo rm -rf $(brew --prefix)/Cellar/eg-client/0.0.1
                 brew cleanup
             fi
-        `)
+        `, ignore_errors)
     } else {
         let platform = os__WEBPACK_IMPORTED_MODULE_0__.platform();
         core.setFailed(`${platform} not supported`);

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -3976,7 +3976,7 @@ exports.default = _default;
 const core = __nccwpck_require__(186);
 const exec = __nccwpck_require__(514);
 
-async function shell(command) {
+async function shell(command, ignore_errors = false) {
     try {
         const args = [
             "-c",
@@ -3984,11 +3984,13 @@ async function shell(command) {
         ];
         return await exec.exec("/bin/sh", args);
     } catch (error) {
-        core.setFailed(error.message);
+        if (!ignore_errors) {
+            core.setFailed(error.message);
+        }
     }
 }
 
-async function powershell(command) {
+async function powershell(command, ignore_errors = false) {
     try {
         const args = [
             "-ExecutionPolicy",
@@ -3998,11 +4000,13 @@ async function powershell(command) {
         ];
         await exec.exec("powershell.exe", args);
     } catch (error) {
-        core.setFailed(error.message);
+        if (!ignore_errors) {
+            core.setFailed(error.message);
+        }
     }
 }
 
-async function cmd(command) {
+async function cmd(command, ignore_errors = false) {
     try {
         const args = [
             "/c",
@@ -4010,7 +4014,9 @@ async function cmd(command) {
         ];
         await exec.exec("cmd.exe", args);
     } catch (error) {
-        core.setFailed(error.message);
+        if (!ignore_errors) {
+            core.setFailed(error.message);
+        }
     }
 }
 

--- a/shell.js
+++ b/shell.js
@@ -1,7 +1,7 @@
 const core = require('@actions/core');
 const exec = require("@actions/exec");
 
-async function shell(command) {
+async function shell(command, ignore_errors = false) {
     try {
         const args = [
             "-c",
@@ -9,11 +9,13 @@ async function shell(command) {
         ];
         return await exec.exec("/bin/sh", args);
     } catch (error) {
-        core.setFailed(error.message);
+        if (!ignore_errors) {
+            core.setFailed(error.message);
+        }
     }
 }
 
-async function powershell(command) {
+async function powershell(command, ignore_errors = false) {
     try {
         const args = [
             "-ExecutionPolicy",
@@ -23,11 +25,13 @@ async function powershell(command) {
         ];
         await exec.exec("powershell.exe", args);
     } catch (error) {
-        core.setFailed(error.message);
+        if (!ignore_errors) {
+            core.setFailed(error.message);
+        }
     }
 }
 
-async function cmd(command) {
+async function cmd(command, ignore_errors = false) {
     try {
         const args = [
             "/c",
@@ -35,7 +39,9 @@ async function cmd(command) {
         ];
         await exec.exec("cmd.exe", args);
     } catch (error) {
-        core.setFailed(error.message);
+        if (!ignore_errors) {
+            core.setFailed(error.message);
+        }
     }
 }
 


### PR DESCRIPTION
shell.js sets core.setFailed, preventing the parent from handling the
error and ignoring it.

Run the shell commands ignoring the failures.
